### PR TITLE
Add broadcasting and transaction signing support

### DIFF
--- a/lightsteem/broadcast/base58.py
+++ b/lightsteem/broadcast/base58.py
@@ -1,0 +1,192 @@
+from binascii import hexlify, unhexlify
+import hashlib
+import string
+import logging
+from .utils import compat_bytes
+
+log = logging.getLogger(__name__)
+
+""" Default Prefix """
+PREFIX = "STM"
+
+known_prefixes = [
+    PREFIX,
+    "TST",
+]
+
+
+class Base58(object):
+    """Base58 base class
+
+    This class serves as an abstraction layer to deal with base58 encoded
+    strings and their corresponding hex and binary representation
+    throughout the library.
+
+    :param data: Data to initialize object, e.g. pubkey data, address data,
+    ...
+
+    :type data: hex, wif, bip38 encrypted wif, base58 string
+
+    :param str prefix: Prefix to use for Address/PubKey strings (defaults
+    to ``GPH``)
+
+    :return: Base58 object initialized with ``data``
+
+    :rtype: Base58
+
+    :raises ValueError: if data cannot be decoded
+
+    * ``bytes(Base58)``: Returns the raw data
+    * ``str(Base58)``:   Returns the readable ``Base58CheckEncoded`` data.
+    * ``repr(Base58)``:  Gives the hex representation of the data.
+
+    *  ``format(Base58,_format)`` Formats the instance according to
+    ``_format``:
+
+        * ``"btc"``: prefixed with ``0x80``. Yields a valid btc address
+        * ``"wif"``: prefixed with ``0x00``. Yields a valid wif key
+        * ``"bts"``: prefixed with ``BTS``
+        * etc.
+
+    """
+
+    def __init__(self, data, prefix=PREFIX):
+        self._prefix = prefix
+        if all(c in string.hexdigits for c in data):
+            self._hex = data
+        elif data[0] == "5" or data[0] == "6":
+            self._hex = base58CheckDecode(data)
+        elif data[0] == "K" or data[0] == "L":
+            self._hex = base58CheckDecode(data)[:-2]
+        elif data[:len(self._prefix)] == self._prefix:
+            self._hex = gphBase58CheckDecode(data[len(self._prefix):])
+        else:
+            raise ValueError("Error loading Base58 object")
+
+    def __format__(self, _format):
+        """ Format output according to argument _format (wif,btc,...)
+
+            :param str _format: Format to use
+            :return: formatted data according to _format
+            :rtype: str
+
+        """
+        if _format.upper() == "WIF":
+            return base58CheckEncode(0x80, self._hex)
+        elif _format.upper() == "ENCWIF":
+            return base58encode(self._hex)
+        elif _format.upper() == "BTC":
+            return base58CheckEncode(0x00, self._hex)
+        elif _format.upper() in known_prefixes:
+            return _format.upper() + str(self)
+        else:
+            log.warn("Format %s unkown. You've been warned!\n" % _format)
+            return _format.upper() + str(self)
+
+    def __repr__(self):
+        """ Returns hex value of object
+
+            :return: Hex string of instance's data
+            :rtype: hex string
+        """
+        return self._hex
+
+    def __str__(self):
+        """ Return graphene-base58CheckEncoded string of data
+
+            :return: Base58 encoded data
+            :rtype: str
+        """
+        return gphBase58CheckEncode(self._hex)
+
+    def __bytes__(self):
+        """ Return raw bytes
+
+            :return: Raw bytes of instance
+            :rtype: bytes
+
+        """
+        return unhexlify(self._hex)
+
+
+# https://github.com/tochev/python3-cryptocoins/raw/master/cryptocoins/base58.py
+BASE58_ALPHABET = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def base58decode(base58_str):
+    base58_text = base58_str.encode('ascii')
+    n = 0
+    leading_zeroes_count = 0
+    for b in base58_text:
+        n = n * 58 + BASE58_ALPHABET.find(b)
+        if n == 0:
+            leading_zeroes_count += 1
+    res = bytearray()
+    while n >= 256:
+        div, mod = divmod(n, 256)
+        res.insert(0, mod)
+        n = div
+    else:
+        res.insert(0, n)
+    return hexlify(bytearray(1) * leading_zeroes_count + res).decode('ascii')
+
+
+def base58encode(hexstring):
+    byteseq = compat_bytes(hexstring, 'ascii')
+    byteseq = unhexlify(byteseq)
+    byteseq = compat_bytes(byteseq)
+
+    n = 0
+    leading_zeroes_count = 0
+    for c in byteseq:
+        n = n * 256 + c
+        if n == 0:
+            leading_zeroes_count += 1
+    res = bytearray()
+    while n >= 58:
+        div, mod = divmod(n, 58)
+        res.insert(0, BASE58_ALPHABET[mod])
+        n = div
+    else:
+        res.insert(0, BASE58_ALPHABET[n])
+
+    return (BASE58_ALPHABET[0:1] * leading_zeroes_count + res).decode('ascii')
+
+
+def ripemd160(s):
+    ripemd160 = hashlib.new('ripemd160')
+    ripemd160.update(unhexlify(s))
+    return ripemd160.digest()
+
+
+def doublesha256(s):
+    return hashlib.sha256(hashlib.sha256(unhexlify(s)).digest()).digest()
+
+
+def base58CheckEncode(version, payload):
+    s = ('%.2x' % version) + payload
+    checksum = doublesha256(s)[:4]
+    result = s + hexlify(checksum).decode('ascii')
+    return base58encode(result)
+
+
+def base58CheckDecode(s):
+    s = unhexlify(base58decode(s))
+    dec = hexlify(s[:-4]).decode('ascii')
+    checksum = doublesha256(dec)[:4]
+    assert (s[-4:] == checksum)
+    return dec[2:]
+
+
+def gphBase58CheckEncode(s):
+    checksum = ripemd160(s)[:4]
+    result = s + hexlify(checksum).decode('ascii')
+    return base58encode(result)
+
+
+def gphBase58CheckDecode(s):
+    s = unhexlify(base58decode(s))
+    dec = hexlify(s[:-4]).decode('ascii')
+    checksum = ripemd160(dec)[:4]
+    assert (s[-4:] == checksum)
+    return dec

--- a/lightsteem/broadcast/chains.py
+++ b/lightsteem/broadcast/chains.py
@@ -1,0 +1,21 @@
+known_chains = {
+    "STEEM": {
+        "chain_id": "0" * int(256 / 4),
+        "prefix": "STM",
+        "steem_symbol": "STEEM",
+        "sbd_symbol": "SBD",
+        "vests_symbol": "VESTS",
+    },
+    "TEST": {
+        "chain_id":
+            "9afbce9f2416520733bacb370315d32b6b2c43d6097576df1c1222859d91eecc",
+        "prefix":
+            "TST",
+        "steem_symbol":
+            "TESTS",
+        "sbd_symbol":
+            "TBD",
+        "vests_symbol":
+            "VESTS",
+    },
+}

--- a/lightsteem/broadcast/key_objects.py
+++ b/lightsteem/broadcast/key_objects.py
@@ -1,0 +1,204 @@
+from .utils import compat_bytes
+
+from .base58 import Base58, ripemd160
+from binascii import hexlify, unhexlify
+
+import ecdsa
+import hashlib
+
+
+class Address(object):
+    """ Address class
+
+        This class serves as an address representation for Public Keys.
+
+        :param str address: Base58 encoded address (defaults to ``None``)
+        :param str pubkey: Base58 encoded pubkey (defaults to ``None``)
+        :param str prefix: Network prefix (defaults to ``GPH``)
+
+        Example::
+
+           Address("GPHFN9r6VYzBK8EKtMewfNbfiGCr56pHDBFi")
+
+    """
+
+    def __init__(self, address=None, pubkey=None, prefix="STM"):
+        self.prefix = prefix
+        if pubkey is not None:
+            self._pubkey = Base58(pubkey, prefix=prefix)
+            self._address = None
+        elif address is not None:
+            self._pubkey = None
+            self._address = Base58(address, prefix=prefix)
+        else:
+            raise Exception("Address has to be initialized by either the " +
+                            "pubkey or the address.")
+
+    def derivesha256address(self):
+        """ Derive address using ``RIPEMD160(SHA256(x))`` """
+        pkbin = unhexlify(repr(self._pubkey))
+        addressbin = ripemd160(hexlify(hashlib.sha256(pkbin).digest()))
+        return Base58(hexlify(addressbin).decode('ascii'))
+
+    def derivesha512address(self):
+        """ Derive address using ``RIPEMD160(SHA512(x))`` """
+        pkbin = unhexlify(repr(self._pubkey))
+        addressbin = ripemd160(hexlify(hashlib.sha512(pkbin).digest()))
+        return Base58(hexlify(addressbin).decode('ascii'))
+
+    def __repr__(self):
+        """ Gives the hex representation of the ``GrapheneBase58CheckEncoded``
+            Graphene address.
+        """
+        return repr(self.derivesha512address())
+
+    def __str__(self):
+        """ Returns the readable Graphene address. This call is equivalent to
+            ``format(Address, "GPH")``
+        """
+        return format(self, self.prefix)
+
+    def __format__(self, _format):
+        """  May be issued to get valid "MUSE", "PLAY" or any other Graphene compatible
+            address with corresponding prefix.
+        """
+        if self._address is None:
+            if _format.lower() == "btc":
+                return format(self.derivesha256address(), _format)
+            else:
+                return format(self.derivesha512address(), _format)
+        else:
+            return format(self._address, _format)
+
+    def __bytes__(self):
+        """ Returns the raw content of the ``Base58CheckEncoded`` address """
+        if self._address is None:
+            return compat_bytes(self.derivesha512address())
+        else:
+            return compat_bytes(self._address)
+
+
+class PublicKey(object):
+
+    def __init__(self, pk, prefix="STM"):
+        self.prefix = prefix
+        self._pk = Base58(pk, prefix=prefix)
+        self.address = Address(pubkey=pk, prefix=prefix)
+        self.pubkey = self._pk
+
+    def _derive_y_from_x(self, x, is_even):
+        """ Derive y point from x point """
+        curve = ecdsa.SECP256k1.curve
+        # The curve equation over F_p is:
+        #   y^2 = x^3 + ax + b
+        a, b, p = curve.a(), curve.b(), curve.p()
+        alpha = (pow(x, 3, p) + a * x + b) % p
+        beta = ecdsa.numbertheory.square_root_mod_prime(alpha, p)
+        if (beta % 2) == is_even:
+            beta = p - beta
+        return beta
+
+    def compressed(self):
+        """ Derive compressed public key """
+        order = ecdsa.SECP256k1.generator.order()
+        p = ecdsa.VerifyingKey.from_string(
+            compat_bytes(self), curve=ecdsa.SECP256k1).pubkey.point
+        x_str = ecdsa.util.number_to_string(p.x(), order)
+        # y_str = ecdsa.util.number_to_string(p.y(), order)
+        compressed = hexlify(
+            compat_bytes(chr(2 + (p.y() & 1)), 'ascii') + x_str).decode(
+            'ascii')
+        return (compressed)
+
+    def unCompressed(self):
+        """ Derive uncompressed key """
+        public_key = repr(self._pk)
+        prefix = public_key[0:2]
+        if prefix == "04":
+            return public_key
+        assert prefix == "02" or prefix == "03"
+        x = int(public_key[2:], 16)
+        y = self._derive_y_from_x(x, (prefix == "02"))
+        key = '04' + '%064x' % x + '%064x' % y
+        return key
+
+    def point(self):
+        """ Return the point for the public key """
+        string = unhexlify(self.unCompressed())
+        return ecdsa.VerifyingKey.from_string(
+            string[1:], curve=ecdsa.SECP256k1).pubkey.point
+
+    def __repr__(self):
+        """ Gives the hex representation of the Graphene public key. """
+        return repr(self._pk)
+
+    def __str__(self):
+        """ Returns the readable Graphene public key. This call is equivalent to
+            ``format(PublicKey, "GPH")``
+        """
+        return format(self._pk, self.prefix)
+
+    def __format__(self, _format):
+        """ Formats the instance of:doc:`Base58 <base58>` according
+        to ``_format`` """
+        return format(self._pk, _format)
+
+    def __bytes__(self):
+        """ Returns the raw public key (has length 33)"""
+        return compat_bytes(self._pk)
+
+
+class PrivateKey(object):
+    def __init__(self, wif=None, prefix="STM"):
+        if wif is None:
+            import os
+            self._wif = Base58(hexlify(os.urandom(32)).decode('ascii'))
+        elif isinstance(wif, Base58):
+            self._wif = wif
+        else:
+            self._wif = Base58(wif)
+        # compress pubkeys only
+        self._pubkeyhex, self._pubkeyuncompressedhex = self.compressedpubkey()
+        self.pubkey = PublicKey(self._pubkeyhex, prefix=prefix)
+        self.uncompressed = PublicKey(
+            self._pubkeyuncompressedhex, prefix=prefix)
+        self.uncompressed.address = Address(
+            pubkey=self._pubkeyuncompressedhex, prefix=prefix)
+        self.address = Address(pubkey=self._pubkeyhex, prefix=prefix)
+
+    def compressedpubkey(self):
+        """ Derive uncompressed public key """
+        secret = unhexlify(repr(self._wif))
+        order = ecdsa.SigningKey.from_string(
+            secret, curve=ecdsa.SECP256k1).curve.generator.order()
+        p = ecdsa.SigningKey.from_string(
+            secret, curve=ecdsa.SECP256k1).verifying_key.pubkey.point
+        x_str = ecdsa.util.number_to_string(p.x(), order)
+        y_str = ecdsa.util.number_to_string(p.y(), order)
+        compressed = hexlify(
+            chr(2 + (p.y() & 1)).encode('ascii') + x_str
+        ).decode('ascii')
+        uncompressed = hexlify(
+            chr(4).encode('ascii') + x_str + y_str).decode(
+            'ascii')
+        return [compressed, uncompressed]
+
+    def __format__(self, _format):
+        """ Formats the instance of:doc:`Base58 <base58>` according to
+            ``_format``
+        """
+        return format(self._wif, _format)
+
+    def __repr__(self):
+        """ Gives the hex representation of the Graphene private key."""
+        return repr(self._wif)
+
+    def __str__(self):
+        """ Returns the readable (uncompressed wif format) Graphene private key. This
+            call is equivalent to ``format(PrivateKey, "WIF")``
+        """
+        return format(self._wif, "WIF")
+
+    def __bytes__(self):
+        """ Returns the raw private key """
+        return compat_bytes(self._wif)

--- a/lightsteem/broadcast/transaction_builder.py
+++ b/lightsteem/broadcast/transaction_builder.py
@@ -1,0 +1,196 @@
+import array
+import hashlib
+import struct
+import time
+from binascii import hexlify
+from binascii import unhexlify
+from collections import OrderedDict
+from datetime import timedelta
+
+import ecdsa
+from dateutil.parser import parse
+
+from .chains import known_chains
+from .key_objects import PrivateKey
+from .utils import compat_bytes
+
+try:
+    import secp256k1
+    USE_SECP256K1 = True
+except ImportError:
+    USE_SECP256K1 = False
+
+
+class TransactionBuilder:
+
+    def __init__(self, client):
+        self.client = client
+        self.transaction = OrderedDict()
+        self.message = None
+        self.digest = None
+
+    def prepare(self):
+        properties = self.client.get_dynamic_global_properties()
+        ref_block_num = properties["head_block_number"] - 3 & 0xFFFF
+        ref_block = self.client.get_block(properties["head_block_number"] - 2)
+        ref_block_prefix = struct.unpack_from("<I", unhexlify(
+            ref_block["previous"]), 4)[0]
+        expiration = (
+                parse(properties["time"]) + timedelta(seconds=30)
+        ).strftime('%Y-%m-%dT%H:%M:%S%Z')
+        self.transaction["ref_block_num"] = ref_block_num
+        self.transaction["ref_block_prefix"] = ref_block_prefix
+        self.transaction["expiration"] = expiration
+
+        return self
+
+    def get_known_chains(self):
+        return known_chains
+
+    def get_chain_params(self, chain):
+        chains = self.get_known_chains()
+        if isinstance(chain, str) and chain in chains:
+            chain_params = chains[chain]
+        elif isinstance(chain, dict):
+            chain_params = chain
+        else:
+            raise Exception("Invalid chain")
+
+        return chain_params
+
+    def derive_digest(self, chain, hex):
+        chain_params = self.get_chain_params(chain)
+        self.chainid = chain_params["chain_id"]
+        self.message = unhexlify(self.chainid + hex[0:-2])
+        self.digest = hashlib.sha256(self.message).digest()
+
+    def recover_public_key(self, digest, signature, i):
+        curve = ecdsa.SECP256k1.curve
+        G = ecdsa.SECP256k1.generator
+        order = ecdsa.SECP256k1.order
+        yp = (i % 2)
+        r, s = ecdsa.util.sigdecode_string(signature, order)
+        x = r + (i // 2) * order
+        alpha = ((x * x * x) + (curve.a() * x) + curve.b()) % curve.p()
+        beta = ecdsa.numbertheory.square_root_mod_prime(alpha, curve.p())
+        y = beta if (beta - yp) % 2 == 0 else curve.p() - beta
+        R = ecdsa.ellipticcurve.Point(curve, x, y, order)
+        e = ecdsa.util.string_to_number(digest)
+        Q = ecdsa.numbertheory.inverse_mod(r, order) * (s * R +
+                                                        (-e % order) * G)
+        if not ecdsa.VerifyingKey.from_public_point(
+                Q, curve=ecdsa.SECP256k1).verify_digest(
+                    signature, digest, sigdecode=ecdsa.util.sigdecode_string):
+            return None
+        return ecdsa.VerifyingKey.from_public_point(Q, curve=ecdsa.SECP256k1)
+
+    def compressed_pubkey(self, pk):
+        order = pk.curve.generator.order()
+        p = pk.pubkey.point
+        x_str = ecdsa.util.number_to_string(p.x(), order)
+        return compat_bytes(chr(2 + (p.y() & 1)), 'ascii') + x_str
+
+    def recover_pubkey_parameter(self, digest, signature, pubkey):
+        for i in range(0, 4):
+            if USE_SECP256K1:
+                sig = pubkey.ecdsa_recoverable_deserialize(signature, i)
+                p = secp256k1.PublicKey(
+                    pubkey.ecdsa_recover(self.message, sig))
+                if p.serialize() == pubkey.serialize():
+                    return i
+            else:
+                p = self.recover_public_key(digest, signature, i)
+                if (p.to_string() == pubkey.to_string()
+                        or self.compressed_pubkey(p) == pubkey.to_string()):
+                    return i
+        return None
+
+    def _is_canonical(self, sig):
+        return (not (sig[0] & 0x80)
+                and not (sig[0] == 0 and not (sig[1] & 0x80))
+                and not (sig[32] & 0x80)
+                and not (sig[32] == 0 and not (sig[33] & 0x80)))
+
+    def broadcast(self, operations, chain=None):
+        if not isinstance(operations, list):
+            operations = [operations, ]
+
+        self.prepare()
+
+        op_list = []
+        for operation in operations:
+            op_list.append(
+                [operation.op_id, operation.op_data],
+            )
+
+        self.transaction["operations"] = op_list
+        self.transaction["extensions"] = []
+        self.transaction["signatures"] = []
+
+        tx_hex = self.client.get_transaction_hex(self.transaction)
+        self.derive_digest(chain, tx_hex)
+
+        sigs = []
+        for wif in self.client.keys:
+            p = compat_bytes(PrivateKey(wif))
+            i = 0
+            if USE_SECP256K1:
+                ndata = secp256k1.ffi.new("const int *ndata")
+                ndata[0] = 0
+                while True:
+                    ndata[0] += 1
+                    privkey = secp256k1.PrivateKey(p, raw=True)
+                    sig = secp256k1.ffi.new(
+                        'secp256k1_ecdsa_recoverable_signature *')
+                    signed = secp256k1.lib.secp256k1_ecdsa_sign_recoverable(
+                        privkey.ctx, sig, self.digest, privkey.private_key,
+                        secp256k1.ffi.NULL, ndata)
+                    assert signed == 1
+                    signature, i = privkey.ecdsa_recoverable_serialize(sig)
+                    if self._is_canonical(signature):
+                        i += 4
+                        i += 27
+                        break
+            else:
+                cnt = 0
+                sk = ecdsa.SigningKey.from_string(p, curve=ecdsa.SECP256k1)
+                while 1:
+                    cnt += 1
+                    if not cnt % 20:
+                        print("Still searching for a canonical signature. "
+                              "Tried %d times already!" % cnt)
+
+                    k = ecdsa.rfc6979.generate_k(
+                        sk.curve.generator.order(),
+                        sk.privkey.secret_multiplier,
+                        hashlib.sha256,
+                        hashlib.sha256(
+                            self.digest + struct.pack("d", time.time(
+                            ))
+                        ).digest())
+
+                    sigder = sk.sign_digest(
+                        self.digest, sigencode=ecdsa.util.sigencode_der, k=k)
+
+                    r, s = ecdsa.util.sigdecode_der(sigder,
+                                                    sk.curve.generator.order())
+                    signature = ecdsa.util.sigencode_string(
+                        r, s, sk.curve.generator.order())
+
+                    sigder = array.array('B', sigder)
+                    lenR = sigder[3]
+                    lenS = sigder[5 + lenR]
+                    if lenR is 32 and lenS is 32:
+                        i = self.recover_pubkey_parameter(
+                            self.digest, signature, sk.get_verifying_key())
+                        i += 4
+                        i += 27
+                        break
+
+            sigstr = struct.pack("<B", i)
+            sigstr += signature
+            sigs.append(hexlify(sigstr).decode('ascii'))
+
+        self.transaction["signatures"] = sigs
+
+        return self.client.broadcast_transaction(self.transaction)

--- a/lightsteem/broadcast/utils.py
+++ b/lightsteem/broadcast/utils.py
@@ -1,0 +1,11 @@
+from builtins import bytes
+
+
+def compat_bytes(item, encoding=None):
+    if hasattr(item, '__bytes__'):
+        return item.__bytes__()
+    else:
+        if encoding:
+            return bytes(item, encoding)
+        else:
+            return bytes(item)

--- a/lightsteem/datastructures.py
+++ b/lightsteem/datastructures.py
@@ -1,0 +1,3 @@
+from collections import namedtuple
+
+Operation = namedtuple('Operation', ['op_id', 'op_data'])

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     author='emre yilmaz',
     author_email='mail@emreyilmaz.me',
     description='A light python client to interact with the STEEM blockchain',
-    install_requires=["requests", "backoff"]
+    install_requires=["requests", "backoff", "ecdsa", "dateutils"]
 )


### PR DESCRIPTION
- Half of the Transaction signing stuff is derived from steem-python.
- Used ```get_transaction_hex``` call of steemd instead of porting serializers. 
- This feature brought edcsa and dateutils as new requirements

Example to broadcast a transaction:

```python
from lightsteem.client import Client
from lightsteem.datastructures import Operation

c = Client(
    keys=["<private_key>",])

op = Operation('account_witness_vote', {
        'account': '<your_account>',
        'witness': 'emrebeyler',
        'approve': True,
    })


c.broadcast(op)

```