### PR TITLE
Add Account helper

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -1,0 +1,176 @@
+
+Helpers
+=================================
+
+Lightsteem has a target to define helper classes for well known blockchain objects. This is
+designed in that way to prevent code repeat on client (library user) side.
+
+It's possible to use lightsteem for just a client. However, if you need to get an
+account's history, or get followers of account, you may use the helpers module.
+
+Account helper
+=================================
+
+This class defines an Account in the STEEM blockchain.
+
+.. code-block:: python
+
+    from lightsteem.client import Client
+    c = Client()
+    account = c.get_account('emrebeyler')
+
+When you execute that script in your REPL, lightsteem makes a RPC call to get the account data
+from the blockchain. Once you initialized the Account instance, you have access to these helper methods:
+
+Getting account history
+-----------------------------------
+
+With this method, you can traverse entire history of a STEEM account.
+
+.. function:: history(self, account=None, limit=1000, filter=None, exclude=None,
+                        order="desc", only_operation_data=True,
+                        start_at=None, stop_at=None):
+
+    :param account: (string) The username.
+    :param limit: (integer) Batch size per call.
+    :param filter: (list:string) Operation types to filter
+    :param exclude: (list:s tring) Operation types to exclude
+    :param order: (string) asc or desc.
+    :param only_operation_data: (bool) If false, returns in the raw format. (Includes transaction information.)
+    :param start_at: (datetime.datetime) Starts after that time to process ops.
+    :param stop_at: (datetime.datetime) Stops at that time while processing ops.
+
+account_history is an important call for the STEEM applications. A few use cases:
+
+- Getting incoming delegations
+- Filtering transfers on specific accounts
+- Getting author, curation rewards
+
+etc.
+
+**Example: Get all incoming STEEM of binance account in the last 7 days**
+
+.. code-block:: python
+
+    import datetime
+
+    from lightsteem.client import Client
+    from lightsteem.helpers.amount import Amount
+
+    client = Client()
+    account = client.account('deepcrypto8')
+
+    one_week_ago = datetime.datetime.utcnow() -
+        datetime.timedelta(days=7)
+    total_steem = 0
+    for op in account.history(
+            stop_at=one_week_ago,
+            filter=["transfer"]):
+
+        if op["to"] != "deepcrypto8":
+            continue
+
+        total_steem += Amount(op["amount"]).amount
+
+    print("Total STEEM deposited to Binance", total_steem)
+
+
+Getting account followers
+-----------------------------------
+
+.. code-block:: python
+
+    from lightsteem.client import Client
+
+    client = Client()
+    account = client.account('deepcrypto8')
+
+    print(account.followers())
+
+Output will be a list of usernames. (string)
+
+
+Getting account followings
+-----------------------------------
+
+.. code-block:: python
+
+    from lightsteem.client import Client
+
+    client = Client()
+    account = client.account('emrebeyler')
+
+    print(account.following())
+
+Output will be a list of usernames. (string)
+
+Getting account ignorers (Muters)
+-----------------------------------
+
+.. code-block:: python
+
+    from lightsteem.client import Client
+
+    client = Client()
+    account = client.account('emrebeyler')
+
+    print(account.ignorers())
+
+
+Getting account ignorings (Muted list)
+-----------------------------------
+
+.. code-block:: python
+
+    from lightsteem.client import Client
+
+    client = Client()
+    account = client.account('emrebeyler')
+
+    print(account.ignorings())
+
+Getting voting power
+-----------------------------------
+
+This helper method determines the account's voting power. In default, It considers
+account's regenerated VP. (Actual VP)
+
+If you want the VP at the time the last vote casted, you can pass consider_regeneration=False.
+
+.. code-block:: python
+
+    from lightsteem.client import Client
+
+    client = Client()
+    account = client.account('emrebeyler')
+
+    print(account.vp())
+    print(account.vp(consider_regeneration=False))
+
+Getting account reputation
+-----------------------------------
+
+.. code-block:: python
+
+    from lightsteem.client import Client
+
+    client = Client()
+    account = client.account('emrebeyler')
+
+    print(account.reputation())
+
+Default precision is 2. You can set it by passing precision=N parameter.
+
+Amount helper
+=================================
+
+A simple class to convert "1234.1234 STEEM" kind of values to Decimal.
+
+.. code-block:: python
+
+    from lightsteem.helpers.amount import Amount
+
+    amount = Amount("42.5466 STEEM")
+
+    print(amount.amount)
+    print(amount.symbol)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,3 +44,4 @@ Documentation Pages
    retryandfailover
    broadcasting
    batch_rpc_calls
+   helpers

--- a/lightsteem/client.py
+++ b/lightsteem/client.py
@@ -7,6 +7,8 @@ import requests
 
 from .exceptions import RPCNodeException
 from .broadcast.transaction_builder import TransactionBuilder
+from .helpers.account import Account
+
 
 DEFAULT_NODES = [
     "https://api.steemit.com",
@@ -162,3 +164,6 @@ class Client:
 
     def broadcast(self, op):
         return self.transaction_builder.broadcast(op, chain=self.chain)
+
+    def account(self, username):
+        return Account(self, username)

--- a/lightsteem/exceptions.py
+++ b/lightsteem/exceptions.py
@@ -4,3 +4,7 @@ class RPCNodeException(Exception):
         super().__init__(message)
         self.code = code
         self.raw_body = raw_body
+
+
+class StopOuterIteration(Exception):
+    pass

--- a/lightsteem/helpers/account.py
+++ b/lightsteem/helpers/account.py
@@ -1,0 +1,209 @@
+import datetime
+import math
+
+from dateutil.parser import parse
+
+from lightsteem.exceptions import StopOuterIteration
+
+
+class Account:
+
+    def __init__(self, client, username=None):
+        self.client = client
+        self.username = username
+        self.raw_data = None
+
+        if username:
+            self._pull_user_data(username)
+
+    def _pull_user_data(self, username):
+        accounts = self.client.get_accounts([username])
+        if not len(accounts):
+            raise ValueError("Username doesn't exist.")
+        self.raw_data = accounts[0]
+
+        return self
+
+    def _get_account_history(self, account, index, limit,
+                             order="desc", filter=None, exclude=None,
+                             only_operation_data=True, start_at=None,
+                             stop_at=None):
+
+        if not filter:
+            filter = []
+
+        if not exclude:
+            exclude = []
+        order = -1 if order == "desc" else 1
+
+        history = self.client.get_account_history(account, index, limit)
+        for transaction in history[::order]:
+
+            created_at = parse(transaction[1]["timestamp"])
+            if start_at and order == -1 and created_at > start_at:
+                continue
+
+            if start_at and order != -1 and created_at < start_at:
+                continue
+
+            if stop_at and order == -1 and created_at < stop_at:
+                raise StopOuterIteration
+
+            if stop_at and order != -1 and created_at > stop_at:
+                raise StopOuterIteration
+
+            op_type, op_value = transaction[1]["op"]
+            if op_type in exclude:
+                continue
+
+            if filter and op_type not in filter:
+                continue
+
+            yield op_value if only_operation_data else transaction
+
+    def history(self, account=None, limit=1000,
+                filter=None, exclude=None,
+                order="desc", only_operation_data=True,
+                start_at=None, stop_at=None):
+        if not account:
+            account = self.username
+
+        # @todo: this can be faster with batch calls.
+        # consider a way to implement it.
+        max_index = self.client.get_account_history(account, -1, 0)[0][0]
+        if not max_index:
+            return
+
+        if order == "desc":
+            # Reverse history:
+            # Loop until we process all ops
+            last_processed_index = max_index
+            while last_processed_index > 0:
+                # Ex: if there are 10 ops left and the limit is 20,
+                # change limit to 10.
+                if last_processed_index - limit < 0:
+                    limit = last_processed_index
+
+                try:
+                    for account_history in self._get_account_history(
+                            account, index=last_processed_index,
+                            limit=limit, filter=filter, exclude=exclude,
+                            order=order,
+                            only_operation_data=only_operation_data,
+                            start_at=start_at, stop_at=stop_at):
+                        yield account_history
+                except StopOuterIteration as e:
+                    # make sure the while loop is terminated
+                    break
+
+                # increment limit by one to prevent double hits.
+                last_processed_index -= limit + 1
+        else:
+            last_processed_index = limit
+            while last_processed_index < max_index + limit:
+                try:
+                    for account_history in self._get_account_history(
+                            account, index=last_processed_index,
+                            limit=limit, filter=filter, exclude=exclude,
+                            order=order,
+                            only_operation_data=only_operation_data,
+                            start_at=start_at, stop_at=stop_at):
+                        yield account_history
+                except StopOuterIteration as e:
+                    # make sure the while loop is terminated
+                    break
+                last_processed_index += limit + 1
+
+    def _get_relationships(self, account, start_from="", type="blog",
+                           limit=1000, method="get_followers"):
+
+        start_from_key_map = {
+            "get_followers": "follower",
+            "get_following": "following",
+        }
+
+        relationships = getattr(self.client, method)(
+            account, start_from, type, limit)
+
+        if not len(relationships):
+            return []
+
+        last_user = relationships[-1][start_from_key_map[method]]
+        relationships = [r[start_from_key_map[method]] for r in relationships]
+
+        # if relationship count is equal to the limit, there
+        # might be more. paginate.
+        if len(relationships) >= limit:
+            relationships += self._get_relationships(
+                account,
+                start_from=last_user,
+                type=type,
+                limit=limit,
+                method=method)[1:]
+
+        return relationships
+
+    def followers(self, account=None):
+        if not account:
+            account = self.username
+
+        return self._get_relationships(
+            account,
+            method="get_followers")
+
+    def following(self, account=None):
+        if not account:
+            account = self.username
+
+        return self._get_relationships(
+            account,
+            method="get_following"
+        )
+
+    def ignorers(self, account=None):
+        if not account:
+            account = self.username
+
+        return self._get_relationships(
+            account,
+            type="ignore",
+            method="get_followers"
+        )
+
+    def ignorings(self, account=None):
+        if not account:
+            account = self.username
+
+        return self._get_relationships(
+            account,
+            type="ignore",
+            method="get_following"
+        )
+
+    def vp(self, consider_regeneration=True, precision=2):
+
+        if not consider_regeneration:
+            # the voting power user has after the last vote they casted.
+            return round(self.raw_data['voting_power'] / 100, precision)
+
+        # the voting power user has after the last vote they casted and
+        # recharging factors.
+
+        last_vote_time = parse(self.raw_data['last_vote_time'])
+        diff_in_seconds = (datetime.datetime.utcnow() -
+                           last_vote_time).total_seconds()
+        regenerated_vp = diff_in_seconds * 10000 / 86400 / 5
+        total_vp = (self.raw_data['voting_power'] + regenerated_vp) / 100
+        if total_vp > 100:
+            total_vp = 100
+
+        return round(total_vp, precision)
+
+    def reputation(self, precision=2):
+        rep = int(self.raw_data['reputation'])
+        if rep == 0:
+            return 25
+        score = max([math.log10(abs(rep)) - 9, 0]) * 9 + 25
+        if rep < 0:
+            score = 50 - score
+        return round(score, precision)

--- a/lightsteem/helpers/amount.py
+++ b/lightsteem/helpers/amount.py
@@ -1,0 +1,24 @@
+
+from decimal import Decimal
+
+
+class Amount:
+
+    def __init__(self, amount_data):
+        amount, self.symbol = amount_data.split()
+        self.amount = Decimal(amount)
+        self.raw_data = amount_data
+
+    def _check_type(self, other):
+        if not isinstance(other, Amount):
+            raise TypeError(
+                "This operation only works with two Amount instances.")
+
+    def __str__(self):
+        return f"{self.amount} {self.symbol}"
+
+    def __int__(self):
+        raise ValueError("It's not possible to cast Amount instances to int.")
+
+    def __float__(self):
+        return float(self.amount)

--- a/tests.py
+++ b/tests.py
@@ -1,10 +1,48 @@
 import unittest
+import datetime
+import json
 
 import requests_mock
 
 from lightsteem.client import Client
+from lightsteem.helpers.account import Account
 
 import lightsteem.exceptions
+
+mock_history_max_index = [[3, {
+    'trx_id': '0000000000000000000000000000000000000000', 'block': 25641925,
+    'trx_in_block': 4294967295, 'op_in_trx': 0, 'virtual_op': 7,
+    'timestamp': '2018-09-03T17:24:48', 'op': ['fill_vesting_withdraw',
+                                               {'from_account': 'hellosteem',
+                                                'to_account': 'hellosteem',
+                                                'withdrawn': '187.37083 VESTS',
+                                                'deposited': '0.092 STEEM'}]}]]
+
+
+mock_history = [[1,
+                 {'trx_id': '985bb048e2068cdb311829ad3d76f4dc2947811a',
+                  'block': 25153549, 'trx_in_block': 1, 'op_in_trx': 0,
+                  'virtual_op': 0, 'timestamp': '2018-08-17T18:12:57',
+                  'op': ['transfer',
+                         {'from': 'hellosteem', 'to': 'sekhmet',
+                          'amount': '0.001 STEEM', 'memo': ''}]}],
+                [2,
+                 {'trx_id': 'bb1b6ddf13bcffe5bba8d55c3c37a5c672ff7309',
+                  'block': 25153549, 'trx_in_block': 0, 'op_in_trx': 0,
+                  'virtual_op': 0, 'timestamp': '2018-08-17T18:12:57',
+                  'op': ['limit_order_create',
+                         {'owner': 'hellosteem', 'orderid': 1534529209,
+                          'amount_to_sell': '0.100 STEEM',
+                          'min_to_receive': '100.000 SBD',
+                          'fill_or_kill': False,
+                          'expiration': '1969-12-31T23:59:59'}]}],
+                [3,
+                 {'trx_id': '851c9a4ec9a32855b9981ea6b97c7911abaf8996',
+                  'block': 25153418, 'trx_in_block': 0, 'op_in_trx': 0,
+                  'virtual_op': 0, 'timestamp': '2018-08-17T18:06:24',
+                  'op': ['transfer',
+                         {'from': 'hellosteem', 'to': 'fabien',
+                          'amount': '0.001 STEEM', 'memo': 'Test'}]}]]
 
 
 class TestClient(unittest.TestCase):
@@ -148,6 +186,77 @@ class TestClient(unittest.TestCase):
             self.assertEqual(2, len(self.client.queue))
             self.client.process_batch()
             self.assertEqual(0, len(self.client.queue))
+
+
+class TestAccountHelper(unittest.TestCase):
+
+    def setUp(self):
+        self.client = Client(nodes=TestClient.NODES)
+
+    def test_vp(self):
+        last_vote_time = datetime.datetime.utcnow() - datetime.timedelta(
+            hours=24)
+
+        result = {
+            "last_vote_time": last_vote_time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "voting_power": 7900,
+        }
+        with requests_mock.mock() as m:
+            m.post(TestClient.NODES[0], json={"result": [result]})
+            account = self.client.account('emrebeyler')
+
+        self.assertEqual(99.0, account.vp())
+
+    def test_reputation(self):
+        reputation_sample = '74765490672156'  # 68.86
+        with requests_mock.mock() as m:
+            m.post(
+                TestClient.NODES[0],
+                json={"result": [{"reputation": reputation_sample}]})
+            account = self.client.account('emrebeyler')
+
+        self.assertEqual(68.86, account.reputation())
+
+    def test_account_history_simple(self):
+        def match_max_index_request(request):
+            params = json.loads(request.text)["params"]
+            return params[1] == -1
+
+        def match_non_max_index_request(request):
+            params = json.loads(request.text)["params"]
+            return params[1] != -1
+
+        with requests_mock.mock() as m:
+
+            m.post(TestClient.NODES[0], json={
+                "result": mock_history_max_index},
+                   additional_matcher=match_max_index_request)
+            m.post(TestClient.NODES[0], json={"result": mock_history},
+                   additional_matcher=match_non_max_index_request)
+
+            account = Account(self.client)
+            history = list(account.history(account="hellosteem"))
+            self.assertEqual(3, len(history))
+
+            # check filter
+            history = list(
+                account.history(account="hellosteem", filter=["transfer"]))
+
+            self.assertEqual(2, len(history))
+
+            # check exclude
+            history = list(
+                account.history(account="hellosteem", exclude=["transfer"]))
+
+            self.assertEqual(1, len(history))
+
+            # check only_operation_data
+
+            history = list(
+                account.history(
+                    account="hellosteem", only_operation_data=False))
+
+            self.assertEqual(3, history[0][0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This introduces the helpers module and the first helper: Acccount.

Even though, lightsteem's main target is being light, there will be
helpers for well known blockchain objects (Account, Block, Witness, etc.)
to prevent code repeat on the client (library user) side.

Account module introduces helper functions for

- getting Followers, Followings, Ignorings, Ignorers
- getting a normalized reputation
- getting a normalized voting power
- extensive account history function