### PR TITLE
Support HF20 nodes for VP calculations

### DIFF
--- a/lightsteem/helpers/account.py
+++ b/lightsteem/helpers/account.py
@@ -183,19 +183,28 @@ class Account:
         )
 
     def vp(self, consider_regeneration=True, precision=2):
+        voting_manabar = self.raw_data.get("voting_manabar", {})
+        voting_power = self.raw_data.get(
+            "voting_power", voting_manabar.get("current_mana"))
 
         if not consider_regeneration:
             # the voting power user has after the last vote they casted.
-            return round(self.raw_data['voting_power'] / 100, precision)
+            return round(voting_power / 100, precision)
+
+        last_vote_time = self.raw_data.get(
+            "last_vote_time", voting_manabar.get("last_update_time"))
 
         # the voting power user has after the last vote they casted and
         # recharging factors.
 
-        last_vote_time = parse(self.raw_data['last_vote_time'])
+        last_vote_time = datetime.datetime.utcfromtimestamp(
+            last_vote_time) if isinstance(
+            last_vote_time, int) else parse(last_vote_time)
+
         diff_in_seconds = (datetime.datetime.utcnow() -
                            last_vote_time).total_seconds()
         regenerated_vp = diff_in_seconds * 10000 / 86400 / 5
-        total_vp = (self.raw_data['voting_power'] + regenerated_vp) / 100
+        total_vp = (voting_power + regenerated_vp) / 100
         if total_vp > 100:
             total_vp = 100
 

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import unittest
+import pytz
 
 import requests_mock
 
@@ -159,6 +160,26 @@ class TestAccountHelper(unittest.TestCase):
 
     def setUp(self):
         self.client = Client(nodes=TestClient.NODES)
+
+    def test_vp_with_hf20(self):
+        last_vote_time = datetime.datetime.utcnow() - datetime.timedelta(
+            hours=24)
+
+        utc = pytz.timezone('UTC')
+        last_vote_time = utc.localize(last_vote_time)
+
+        result = {
+            'voting_manabar': {
+                'current_mana': 7900,
+                'last_update_time': int(last_vote_time.timestamp())
+            }
+        }
+
+        with requests_mock.mock() as m:
+            m.post(TestClient.NODES[0], json={"result": [result]})
+            account = self.client.account('emrebeyler')
+
+        self.assertEqual(99, account.vp())
 
     def test_vp(self):
         last_vote_time = datetime.datetime.utcnow() - datetime.timedelta(


### PR DESCRIPTION
Currently, api.steemit.com both returns voting_manabar and the old fields. So, that's ok for now but there will be a point that old fields won't be returning anymore.

New fields:
```
    'voting_manabar': {
        'current_mana': 9595,
        'last_update_time': 1537630719
    },
```

Old fields:

```
    'voting_power': 9595,
    'last_vote_time': '2018-09-22T15:38:39',
``
